### PR TITLE
Feat/ingestion service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,9 @@ $RECYCLE.BIN/
 
 
 # Environment/config (optional, uncomment as needed)
-# .env
+ .env
 # application-local.properties
-# application-dev.properties
+ application-dev.properties
 
 # Ignore dependency downloads
 **/.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ yarn-error.log*
 # ─────────────────────────────────────────────────────────
 # Add any custom or module-specific ignores below as needed
 # ─────────────────────────────────────────────────────────
+tools/akhq-0.25.1-all.jar

--- a/ingestion-service/pom.xml
+++ b/ingestion-service/pom.xml
@@ -3,7 +3,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>com.gracemann.recon</groupId>
         <artifactId>recon-engine</artifactId>
@@ -13,7 +12,6 @@
 
     <artifactId>ingestion-service</artifactId>
     <name>ingestion-service</name>
-    <description>Ingestion Service Microservice</description>
 
     <dependencies>
         <dependency>
@@ -22,9 +20,32 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- Use spring-kafka instead of spring-boot-starter-kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Add more dependencies as needed -->
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/config/KafkaConfig.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/config/KafkaConfig.java
@@ -1,0 +1,143 @@
+package com.gracemann.recon.ingestionservice.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+/**
+ * KafkaConfig is the central configuration for all Kafka producer and consumer
+ * beans
+ * in the ingestion-service. Supports both string (raw JSON) and DTO-based
+ * flows.
+ *
+ * Usage:
+ * - Use {@code KafkaTemplate<String, String>} to send raw JSON payloads to
+ * Kafka.
+ * - Use
+ * {@code @KafkaListener(..., containerFactory = "stringKafkaListenerContainerFactory")}
+ * to consume raw JSON strings from Kafka.
+ * - (Optional) Use DTO-based templates/container factories for advanced use
+ * cases.
+ *
+ * This config is production-ready, easy to extend, and matches common Spring
+ * Boot Kafka best practices.
+ */
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    /**
+     * ProducerFactory for sending raw JSON strings to Kafka.
+     *
+     * Use this to produce raw JSON as String (recommended for most ingestion E2E
+     * flows).
+     */
+    @Bean
+    public ProducerFactory<String, String> stringProducerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        // Optional tuning (e.g., acks, retries) can be added here.
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    /**
+     * KafkaTemplate for sending raw JSON strings.
+     *
+     * Usage: Autowire this bean to send JSON strings to any topic.
+     */
+    @Bean
+    public KafkaTemplate<String, String> stringKafkaTemplate() {
+        return new KafkaTemplate<>(stringProducerFactory());
+    }
+
+    /**
+     * ConsumerFactory for receiving raw JSON strings from Kafka.
+     *
+     * Use this to consume JSON as String, then manually map to DTO in your
+     * listener.
+     */
+    @Bean
+    public ConsumerFactory<String, String> stringConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "recon-ingestion-group");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        // Optional tuning (e.g., max poll records, auto offset reset) can be added
+        // here.
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    /**
+     * KafkaListenerContainerFactory for consuming raw JSON strings.
+     *
+     * Usage: Specify this factory in your @KafkaListener if you want to receive
+     * String payloads.
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> stringKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(stringConsumerFactory());
+        return factory;
+    }
+
+    // --- (Optional) DTO-based Producer/Consumer Factories for advanced usage ---
+
+    // Uncomment/extend if you want to support direct DTO <-> Kafka serialization in
+    // the future.
+    /*
+     * @Bean
+     * public ProducerFactory<String, TxnRecordDTO> dtoProducerFactory() {
+     * Map<String, Object> props = new HashMap<>();
+     * props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+     * props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+     * StringSerializer.class);
+     * props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+     * JsonSerializer.class);
+     * return new DefaultKafkaProducerFactory<>(props);
+     * }
+     *
+     * @Bean
+     * public KafkaTemplate<String, TxnRecordDTO> dtoKafkaTemplate() {
+     * return new KafkaTemplate<>(dtoProducerFactory());
+     * }
+     *
+     * @Bean
+     * public ConsumerFactory<String, TxnRecordDTO> dtoConsumerFactory() {
+     * Map<String, Object> props = new HashMap<>();
+     * props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+     * props.put(ConsumerConfig.GROUP_ID_CONFIG, "recon-ingestion-group");
+     * props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+     * StringDeserializer.class);
+     * props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+     * JsonDeserializer.class);
+     * props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+     * return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new
+     * JsonDeserializer<>(TxnRecordDTO.class, false));
+     * }
+     *
+     * @Bean
+     * public ConcurrentKafkaListenerContainerFactory<String, TxnRecordDTO>
+     * dtoKafkaListenerContainerFactory() {
+     * ConcurrentKafkaListenerContainerFactory<String, TxnRecordDTO> factory = new
+     * ConcurrentKafkaListenerContainerFactory<>();
+     * factory.setConsumerFactory(dtoConsumerFactory());
+     * return factory;
+     * }
+     */
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/consumer/BankTxnConsumer.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/consumer/BankTxnConsumer.java
@@ -1,0 +1,45 @@
+
+/**
+ * Consumer component responsible for consuming raw bank transaction JSON
+ * strings
+ * from Kafka, parsing them into TxnRecordDTO objects, and delegating processing
+ * to the IngestionProcessor.
+ *
+ * Uses stringKafkaListenerContainerFactory to consume raw JSON strings.
+ */
+package com.gracemann.recon.ingestionservice.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gracemann.recon.ingestionservice.dto.TxnRecordDTO;
+import com.gracemann.recon.ingestionservice.processor.IngestionProcessor;
+
+@Component
+public class BankTxnConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final IngestionProcessor processor;
+
+    // Constructor injection for all dependencies
+    public BankTxnConsumer(ObjectMapper objectMapper, IngestionProcessor processor) {
+        this.objectMapper = objectMapper;
+        this.processor = processor;
+    }
+
+    @KafkaListener(
+        topics = "bank-txn-topic",
+        groupId = "recon-ingestion-group",
+        containerFactory = "stringKafkaListenerContainerFactory"
+    )
+    public void consume(String rawJson) {
+        try {
+            TxnRecordDTO dto = objectMapper.readValue(rawJson, TxnRecordDTO.class);
+            processor.process(dto);
+        } catch (Exception e) {
+            // TODO: Use proper logging
+            System.err.println("Error processing bank txn: " + e.getMessage());
+        }
+    }
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/consumer/SchemeTxnConsumer.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/consumer/SchemeTxnConsumer.java
@@ -1,0 +1,48 @@
+
+/**
+ * Consumer component responsible for consuming raw scheme transaction JSON
+ * strings
+ * from Kafka, parsing them into TxnRecordDTO objects, and delegating processing
+ * to the IngestionProcessor.
+ *
+ * Uses stringKafkaListenerContainerFactory to consume raw JSON strings.
+ */
+package com.gracemann.recon.ingestionservice.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gracemann.recon.ingestionservice.dto.TxnRecordDTO;
+import com.gracemann.recon.ingestionservice.processor.IngestionProcessor;
+
+/**
+ * Consumer component responsible for consuming raw scheme transaction JSON
+ * strings from Kafka, parsing them into TxnRecordDTO objects,
+ * and delegating processing to the IngestionProcessor.
+ *
+ * Uses stringKafkaListenerContainerFactory to consume raw JSON strings.
+ */
+@Component
+public class SchemeTxnConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final IngestionProcessor processor;
+
+    // Constructor injection for both dependencies
+    public SchemeTxnConsumer(ObjectMapper objectMapper, IngestionProcessor processor) {
+        this.objectMapper = objectMapper;
+        this.processor = processor;
+    }
+
+    @KafkaListener(topics = "scheme-txn-topic", groupId = "recon-ingestion-group", containerFactory = "stringKafkaListenerContainerFactory")
+    public void consume(String rawJson) {
+        try {
+            TxnRecordDTO dto = objectMapper.readValue(rawJson, TxnRecordDTO.class);
+            processor.process(dto);
+        } catch (Exception e) {
+            // TODO: Integrate with metrics and proper logging framework
+            System.err.println("Error processing scheme txn: " + e.getMessage());
+        }
+    }
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/dto/TxnRecordDTO.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/dto/TxnRecordDTO.java
@@ -1,0 +1,217 @@
+package com.gracemann.recon.ingestionservice.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO for normalized transaction records from either the bank switch or scheme
+ * files.
+ * Used for ingestion, validation, deduplication, and downstream matching.
+ *
+ * - All fields are optional EXCEPT those annotated @NotNull.
+ * - Fields like channel, batchId, schemeName, authCode may be null depending on
+ * sourceType.
+ */
+public class TxnRecordDTO {
+
+    @NotNull
+    private String txnId; // Unique transaction ID (from switch or scheme)
+
+    @NotNull
+    @Size(min = 8, max = 19)
+    private String cardNumber; // Masked or tokenized PAN
+
+    @NotNull
+    @Positive
+    private BigDecimal amount; // Transaction amount
+
+    @NotNull
+    private LocalDateTime txnTimestamp; // Transaction or settlement timestamp
+
+    @NotNull
+    @Size(min = 3, max = 3)
+    private String currency; // ISO 4217 code (e.g., 'INR')
+
+    // Optional fields, present for either bank or scheme as relevant
+    private String merchantId; // Acquirer/merchant identifier
+    private String terminalId; // Terminal/device ID
+    private String responseCode; // ISO 8583 or scheme response/status
+
+    private String channel; // POS/ATM/ECOM, etc. (bank only)
+    private String batchId; // Settlement batch/file ID (scheme only)
+    private String schemeName; // Visa, RuPay, etc. (scheme only)
+    private String authCode; // Authorization code (bank only, optional)
+
+    @NotNull
+    private SourceType sourceType; // BANK_SWITCH or SCHEME_FILE
+
+    private String rawSourceRecord; // Original payload (ISO or scheme record), for trace/debug
+
+    // Constructors
+    public TxnRecordDTO() {
+    }
+
+    public TxnRecordDTO(String txnId, String cardNumber, BigDecimal amount, LocalDateTime txnTimestamp,
+            String currency, String merchantId, String terminalId, String responseCode,
+            String channel, String batchId, String schemeName, String authCode,
+            SourceType sourceType, String rawSourceRecord) {
+        this.txnId = txnId;
+        this.cardNumber = cardNumber;
+        this.amount = amount;
+        this.txnTimestamp = txnTimestamp;
+        this.currency = currency;
+        this.merchantId = merchantId;
+        this.terminalId = terminalId;
+        this.responseCode = responseCode;
+        this.channel = channel;
+        this.batchId = batchId;
+        this.schemeName = schemeName;
+        this.authCode = authCode;
+        this.sourceType = sourceType;
+        this.rawSourceRecord = rawSourceRecord;
+    }
+
+    // Enum for distinguishing source
+    public enum SourceType {
+        BANK_SWITCH, SCHEME_FILE
+    }
+
+    // Getters and Setters
+    // (all same as before, just add get/setAuthCode)
+
+    public String getTxnId() {
+        return txnId;
+    }
+
+    public void setTxnId(String txnId) {
+        this.txnId = txnId;
+    }
+
+    public String getCardNumber() {
+        return cardNumber;
+    }
+
+    public void setCardNumber(String cardNumber) {
+        this.cardNumber = cardNumber;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public LocalDateTime getTxnTimestamp() {
+        return txnTimestamp;
+    }
+
+    public void setTxnTimestamp(LocalDateTime txnTimestamp) {
+        this.txnTimestamp = txnTimestamp;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getMerchantId() {
+        return merchantId;
+    }
+
+    public void setMerchantId(String merchantId) {
+        this.merchantId = merchantId;
+    }
+
+    public String getTerminalId() {
+        return terminalId;
+    }
+
+    public void setTerminalId(String terminalId) {
+        this.terminalId = terminalId;
+    }
+
+    public String getResponseCode() {
+        return responseCode;
+    }
+
+    public void setResponseCode(String responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getBatchId() {
+        return batchId;
+    }
+
+    public void setBatchId(String batchId) {
+        this.batchId = batchId;
+    }
+
+    public String getSchemeName() {
+        return schemeName;
+    }
+
+    public void setSchemeName(String schemeName) {
+        this.schemeName = schemeName;
+    }
+
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public SourceType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(SourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public String getRawSourceRecord() {
+        return rawSourceRecord;
+    }
+
+    public void setRawSourceRecord(String rawSourceRecord) {
+        this.rawSourceRecord = rawSourceRecord;
+    }
+
+    @Override
+    public String toString() {
+        return "TxnRecordDTO{" +
+                "txnId='" + txnId + '\'' +
+                ", cardNumber='" + cardNumber + '\'' +
+                ", amount=" + amount +
+                ", txnTimestamp=" + txnTimestamp +
+                ", currency='" + currency + '\'' +
+                ", merchantId='" + merchantId + '\'' +
+                ", terminalId='" + terminalId + '\'' +
+                ", responseCode='" + responseCode + '\'' +
+                ", channel='" + channel + '\'' +
+                ", batchId='" + batchId + '\'' +
+                ", schemeName='" + schemeName + '\'' +
+                ", authCode='" + authCode + '\'' +
+                ", sourceType=" + sourceType +
+                ", rawSourceRecord='" + rawSourceRecord + '\'' +
+                '}';
+    }
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/events/TxnRecordEvent.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/events/TxnRecordEvent.java
@@ -1,0 +1,5 @@
+package com.gracemann.recon.ingestionservice.events;
+
+public class TxnRecordEvent {
+
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/metrics/IngestionMetrics.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/metrics/IngestionMetrics.java
@@ -1,0 +1,112 @@
+package com.gracemann.recon.ingestionservice.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * IngestionMetrics tracks various counters for the ingestion pipeline,
+ * including:
+ * <ul>
+ * <li>Total transactions received</li>
+ * <li>Duplicate transactions filtered</li>
+ * <li>Successfully processed transactions</li>
+ * <li>Errored transactions</li>
+ * </ul>
+ *
+ * <p>
+ * This component provides thread-safe counters for monitoring ingestion health
+ * and supports integration with metrics frameworks (e.g., Micrometer) in the
+ * future.
+ * </p>
+ *
+ * <p>
+ * Usage: Inject and increment counters during processing to track pipeline
+ * status.
+ * </p>
+ *
+ * @author
+ * @version 1.0
+ */
+@Component
+public class IngestionMetrics {
+
+    private final AtomicLong totalTransactions = new AtomicLong(0);
+    private final AtomicLong dedupedTransactions = new AtomicLong(0);
+    private final AtomicLong successfulTransactions = new AtomicLong(0);
+    private final AtomicLong errorTransactions = new AtomicLong(0);
+
+    /**
+     * Increment the count of total transactions received.
+     */
+    public void incrementTotal() {
+        totalTransactions.incrementAndGet();
+    }
+
+    /**
+     * Increment the count of transactions identified as duplicates and filtered.
+     */
+    public void incrementDeduped() {
+        dedupedTransactions.incrementAndGet();
+    }
+
+    /**
+     * Increment the count of transactions successfully processed and forwarded.
+     */
+    public void incrementSuccess() {
+        successfulTransactions.incrementAndGet();
+    }
+
+    /**
+     * Increment the count of transactions that failed processing due to errors.
+     */
+    public void incrementErrors() {
+        errorTransactions.incrementAndGet();
+    }
+
+    /**
+     * Get the total number of transactions received.
+     *
+     * @return total transaction count
+     */
+    public long getTotalTransactions() {
+        return totalTransactions.get();
+    }
+
+    /**
+     * Get the number of transactions filtered as duplicates.
+     *
+     * @return deduplication count
+     */
+    public long getDedupedTransactions() {
+        return dedupedTransactions.get();
+    }
+
+    /**
+     * Get the number of transactions successfully processed.
+     *
+     * @return success count
+     */
+    public long getSuccessfulTransactions() {
+        return successfulTransactions.get();
+    }
+
+    /**
+     * Get the number of transactions that encountered errors during processing.
+     *
+     * @return error count
+     */
+    public long getErrorTransactions() {
+        return errorTransactions.get();
+    }
+
+    @Override
+    public String toString() {
+        return "IngestionMetrics{" +
+                "totalTransactions=" + getTotalTransactions() +
+                ", dedupedTransactions=" + getDedupedTransactions() +
+                ", successfulTransactions=" + getSuccessfulTransactions() +
+                ", errorTransactions=" + getErrorTransactions() +
+                '}';
+    }
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/processor/IngestionProcessor.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/processor/IngestionProcessor.java
@@ -1,0 +1,92 @@
+package com.gracemann.recon.ingestionservice.processor;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gracemann.recon.ingestionservice.dto.TxnRecordDTO;
+import com.gracemann.recon.ingestionservice.metrics.IngestionMetrics;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+/**
+ * Processes validated & deduplicated transactions and forwards them
+ * to the match-engine topic.
+ */
+@Component
+public class IngestionProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestionProcessor.class);
+    private static final String MATCH_ENGINE_TOPIC = "ingested-txn-topic";
+
+    /** Dedup by composite key = txnId|sourceType */
+    private final Set<String> dedupSet = ConcurrentHashMap.newKeySet();
+
+    private final Validator validator;
+    private final IngestionMetrics metrics;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public IngestionProcessor(IngestionMetrics metrics,
+            KafkaTemplate<String, String> kafkaTemplate,
+            ObjectMapper objectMapper) {
+
+        this.metrics = metrics;
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        this.validator = factory.getValidator();
+    }
+
+    /**
+     * Validate → deduplicate → forward.
+     */
+    public void process(TxnRecordDTO dto) {
+        metrics.incrementTotal();
+
+        // 1️⃣ Validation -----------------------------------------------------
+        Set<ConstraintViolation<TxnRecordDTO>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            metrics.incrementErrors();
+            logValidationErrors(dto, violations);
+            return;
+        }
+
+        // 2️⃣ Deduplication (txnId + sourceType) ---------------------------
+        String dedupKey = dto.getTxnId() + "|" + dto.getSourceType();
+        if (!dedupSet.add(dedupKey)) {
+            metrics.incrementDeduped();
+            log.debug("Deduplicated: {}", dedupKey);
+            return;
+        }
+
+        // 3️⃣ Forward to downstream topic -----------------------------------
+        try {
+            String json = objectMapper.writeValueAsString(dto);
+            kafkaTemplate.send(MATCH_ENGINE_TOPIC, dto.getTxnId(), json);
+            metrics.incrementSuccess();
+            log.info("Forwarded {} to downstream", dedupKey);
+        } catch (Exception e) {
+            metrics.incrementErrors();
+            log.error("Forwarding failed for {}: {}", dedupKey, e.getMessage(), e);
+            // TODO: retry / DLQ for prod
+        }
+    }
+
+    /* --------------------------------------------------------------------- */
+
+    private void logValidationErrors(TxnRecordDTO dto,
+            Set<ConstraintViolation<TxnRecordDTO>> violations) {
+        log.warn("Validation failed for txnId {}:", dto.getTxnId());
+        violations.forEach(v -> log.warn("  {} {}", v.getPropertyPath(), v.getMessage()));
+    }
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/RawCsvTestMessages.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/RawCsvTestMessages.java
@@ -1,0 +1,106 @@
+package com.gracemann.recon.ingestionservice.producer;
+
+/**
+ *
+ * ----------------------------------------------------------------
+ * EXTERNAL VISA/RUPAY SCHMES CLEARING FILES
+ * ----------------------------------------------------------------
+ * Raw CSV test message constants for scheme transaction ingestion testing.
+ *
+ * <p>
+ * This class provides static constants containing raw CSV line strings that
+ * simulate
+ * scheme transaction data files. These messages intentionally include some
+ * "dirty" data
+ * with missing fields, empty values, and malformed entries to test the
+ * ingestion pipeline's
+ * error handling and data validation capabilities.
+ * </p>
+ *
+ * <p>
+ * CSV format follows the order: date, schemeName, txnId, cardNumber, amount,
+ * currency,
+ * merchantId, terminalId, responseCode, batchId
+ * </p>
+ *
+ * <p>
+ * These test constants can be modified as needed to support various ingestion
+ * test scenarios,
+ * including both clean data and edge cases with data quality issues.
+ * </p>
+ *
+ * @author Generated for ingestion testing
+ * @version 1.0
+ */
+public class RawCsvTestMessages {
+
+    /**
+     * Clean scheme transaction - matches BANK-TXN-001 from ISO messages
+     */
+    public static final String VISA_CLEAN_TRANSACTION = "2024-06-20,VISA,BANK-TXN-001,4532123456789012,2500.00,INR,MERCH-101,TERM-101,00,BATCH-001";
+
+    /**
+     * Mastercard transaction with missing terminal ID - matches BANK-TXN-002
+     */
+    public static final String MASTERCARD_MISSING_TERMINAL = "2024-06-20,MASTERCARD,BANK-TXN-002,5234567890123456,5000.00,INR,MERCH-102,,00,BATCH-002";
+
+    /**
+     * RuPay transaction with empty amount field (malformed) - matches BANK-TXN-003
+     */
+    public static final String RUPAY_EMPTY_AMOUNT = "2024-06-20,RUPAY,BANK-TXN-003,4111111111111111,,INR,MERCH-103,TERM-103,00,BATCH-003";
+
+    /**
+     * AMEX transaction with invalid date format - matches BANK-TXN-004
+     */
+    public static final String AMEX_INVALID_DATE = "20/06/2024,AMEX,BANK-TXN-004,6011123456789012,3200.75,USD,MERCH-104,TERM-104,00,BATCH-004";
+
+    /**
+     * Visa transaction with missing batch ID and response code - matches
+     * BANK-TXN-005
+     */
+    public static final String VISA_MISSING_FIELDS = "2024-06-20,VISA,BANK-TXN-005,4532987654321098,10000.00,INR,MERCH-105,TERM-105,,";
+
+    /**
+     * Malformed CSV with too few fields (missing last 3 columns) - additional test
+     * case
+     */
+    public static final String MALFORMED_TOO_FEW_FIELDS = "2024-06-20,MASTERCARD,BANK-TXN-006,5555555555554444,1000.00,INR,MERCH-106";
+
+    /**
+     * Transaction with special characters in merchant ID - additional test case
+     */
+    public static final String SPECIAL_CHARS_MERCHANT = "2024-06-20,VISA,BANK-TXN-007,4532987654321098,750.75,INR,MERCH-107@#$,TERM-107,00,BATCH-007";
+
+    /**
+     * Transaction with negative amount (edge case) - additional test case
+     */
+    public static final String NEGATIVE_AMOUNT = "2024-06-20,RUPAY,BANK-TXN-008,6011987654321098,-500.00,INR,MERCH-108,TERM-108,00,BATCH-008";
+
+    /**
+     * Empty CSV line for testing empty record handling
+     */
+    public static final String EMPTY_LINE = "";
+
+    /**
+     * CSV header line (should be skipped during processing)
+     */
+    public static final String CSV_HEADER = "date,schemeName,txnId,cardNumber,amount,currency,merchantId,terminalId,responseCode,batchId";
+
+    private RawCsvTestMessages() {
+        // Utility class - prevent instantiation
+    }
+
+    public static final String[] ALL_MESSAGES = {
+            VISA_CLEAN_TRANSACTION,
+            MASTERCARD_MISSING_TERMINAL,
+            RUPAY_EMPTY_AMOUNT,
+            AMEX_INVALID_DATE,
+            VISA_MISSING_FIELDS,
+            MALFORMED_TOO_FEW_FIELDS,
+            SPECIAL_CHARS_MERCHANT,
+            NEGATIVE_AMOUNT,
+            EMPTY_LINE,
+            CSV_HEADER
+    };
+
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/RawIsoTestMessages.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/RawIsoTestMessages.java
@@ -1,0 +1,89 @@
+package com.gracemann.recon.ingestionservice.producer;
+
+/**
+ * ----------------------------------------------------------------
+ * INTERNAL BANK LEDGER RAW ISO 8583 MESSAGE PRODUCER SAMPLES
+ * ----------------------------------------------------------------
+ *
+ * Raw ISO8583-like test message constants for bank transaction ingestion
+ * testing.
+ *
+ * <p>
+ * This class provides static constants containing pipe-delimited raw message
+ * strings
+ * that simulate bank transaction data in ISO8583-like format. These messages
+ * are designed
+ * to be pristine and well-formed for testing the ingestion pipeline's happy
+ * path scenarios.
+ * </p>
+ *
+ * <p>
+ * Each message contains all required fields for bank transactions including:
+ * MTI, txnId, cardNumber, amount, txnTimestamp, currency, merchantId,
+ * terminalId,
+ * responseCode, channel, and authCode.
+ * </p>
+ *
+ * <p>
+ * These test constants can be modified as needed to support various ingestion
+ * test scenarios.
+ * </p>
+ *
+ * @author Generated for ingestion testing
+ * @version 1.0
+ */
+public class RawIsoTestMessages {
+
+    /**
+     * Sample POS transaction message - successful purchase
+     */
+    public static final String POS_PURCHASE_SUCCESS = "MTI=0200|txnId=BANK-TXN-001|cardNumber=4532123456789012|amount=2500.00|"
+            +
+            "txnTimestamp=2024-06-20T14:30:15|currency=INR|merchantId=MERCH-001|" +
+            "terminalId=TERM-001|responseCode=00|channel=POS|authCode=AUTH123456";
+
+    /**
+     * Sample ATM withdrawal message - successful transaction
+     */
+    public static final String ATM_WITHDRAWAL_SUCCESS = "MTI=0200|txnId=BANK-TXN-002|cardNumber=5234567890123456|amount=5000.00|"
+            +
+            "txnTimestamp=2024-06-20T15:45:30|currency=INR|merchantId=MERCH-002|" +
+            "terminalId=TERM-002|responseCode=00|channel=ATM|authCode=AUTH789012";
+
+    /**
+     * Sample online transaction message - successful e-commerce purchase
+     */
+    public static final String ONLINE_PURCHASE_SUCCESS = "MTI=0200|txnId=BANK-TXN-003|cardNumber=4111111111111111|amount=1750.50|"
+            +
+            "txnTimestamp=2024-06-20T16:20:45|currency=INR|merchantId=MERCH-003|" +
+            "terminalId=TERM-003|responseCode=00|channel=ONLINE|authCode=AUTH345678";
+
+    /**
+     * Sample mobile banking transaction message - successful transfer
+     */
+    public static final String MOBILE_TRANSFER_SUCCESS = "MTI=0200|txnId=BANK-TXN-004|cardNumber=6011123456789012|amount=3200.75|"
+            +
+            "txnTimestamp=2024-06-20T17:10:12|currency=INR|merchantId=MERCH-004|" +
+            "terminalId=TERM-004|responseCode=00|channel=MOBILE|authCode=AUTH901234";
+
+    /**
+     * Sample declined transaction message - insufficient funds
+     */
+    public static final String POS_PURCHASE_DECLINED = "MTI=0210|txnId=BANK-TXN-005|cardNumber=4532987654321098|amount=10000.00|"
+            +
+            "txnTimestamp=2024-06-20T18:05:33|currency=INR|merchantId=MERCH-005|" +
+            "terminalId=TERM-005|responseCode=51|channel=POS|authCode=";
+
+    private RawIsoTestMessages() {
+        // Utility class - prevent instantiation
+    }
+
+    public static final String[] ALL_MESSAGES = {
+            POS_PURCHASE_SUCCESS,
+            ATM_WITHDRAWAL_SUCCESS,
+            ONLINE_PURCHASE_SUCCESS,
+            MOBILE_TRANSFER_SUCCESS,
+            POS_PURCHASE_DECLINED
+    };
+
+}

--- a/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/TestTxnProducer.java
+++ b/ingestion-service/src/main/java/com/gracemann/recon/ingestionservice/producer/TestTxnProducer.java
@@ -1,0 +1,260 @@
+package com.gracemann.recon.ingestionservice.producer;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.gracemann.recon.ingestionservice.config.KafkaConfig;
+
+/**
+ * TestTxnProducer simulates ingestion of raw bank ISO8583-like messages and
+ * scheme CSV lines INCLUDING INTENTIONALLY BAD DATA for recon engine testing.
+ */
+public class TestTxnProducer {
+
+    private static final DateTimeFormatter ISO_DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    private static final DateTimeFormatter CSV_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter SLASH_DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM/yyyy'T'HH:mm:ss");
+
+    // Standalone mapper, not Spring-injected
+    private static final ObjectMapper mapper = new ObjectMapper();
+    static {
+        mapper.registerModule(new JavaTimeModule());
+    }
+
+    public static void main(String[] args) throws Exception {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(KafkaConfig.class);
+
+        try {
+            KafkaTemplate<String, String> kafkaTemplate = context.getBean("stringKafkaTemplate", KafkaTemplate.class);
+
+            String bankTopic = "bank-txn-topic";
+            String schemeTopic = "scheme-txn-topic";
+
+            // Send bank messages
+            for (String isoRaw : RawIsoTestMessages.ALL_MESSAGES) {
+                try {
+                    String txnId = extractField(isoRaw, "txnId");
+                    String json = parseIsoToJson(isoRaw);
+                    kafkaTemplate.send(bankTopic, txnId, json);
+                    System.out.println("Sent bank message with txnId=" + txnId);
+                } catch (Exception e) {
+                    String fallbackTxnId = "PARSE_ERROR_" + System.currentTimeMillis();
+                    String errorJson = createErrorRecord(isoRaw, "BANK_SWITCH", e.getMessage());
+                    kafkaTemplate.send(bankTopic, fallbackTxnId, errorJson);
+                    System.out.println("Sent error bank message: " + e.getMessage());
+                }
+            }
+
+            // Send scheme messages
+            for (String csvRaw : RawCsvTestMessages.ALL_MESSAGES) {
+                if (csvRaw == null || csvRaw.trim().isEmpty() || csvRaw.startsWith("date,")) {
+                    continue;
+                }
+
+                try {
+                    String txnId = extractTxnIdFromCsv(csvRaw);
+                    String json = parseCsvToJson(csvRaw);
+                    if (json != null) {
+                        kafkaTemplate.send(schemeTopic, txnId, json);
+                        System.out.println("Sent scheme message with txnId=" + txnId);
+                    } else {
+                        String errorJson = createErrorRecord(csvRaw, "SCHEME_FILE", "Failed CSV parsing");
+                        kafkaTemplate.send(schemeTopic, txnId, errorJson);
+                        System.out.println("Sent error scheme message with txnId=" + txnId);
+                    }
+                } catch (Exception e) {
+                    String fallbackTxnId = "CSV_PARSE_ERROR_" + System.currentTimeMillis();
+                    String errorJson = createErrorRecord(csvRaw, "SCHEME_FILE", e.getMessage());
+                    kafkaTemplate.send(schemeTopic, fallbackTxnId, errorJson);
+                    System.out.println("Sent exception scheme message: " + e.getMessage());
+                }
+            }
+        } finally {
+            context.close();
+        }
+    }
+
+    // --- All helper methods below use the static mapper ---
+
+    private static String createErrorRecord(String rawData, String sourceType, String error) throws Exception {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("txnId", "ERROR_" + System.currentTimeMillis());
+        node.putNull("cardNumber");
+        node.putNull("amount");
+        node.putNull("txnTimestamp");
+        node.putNull("currency");
+        node.putNull("merchantId");
+        node.putNull("terminalId");
+        node.putNull("responseCode");
+        node.putNull("channel");
+        node.putNull("batchId");
+        node.putNull("schemeName");
+        node.putNull("authCode");
+        node.put("sourceType", sourceType);
+        node.put("rawSourceRecord", rawData);
+        node.put("parseError", error);
+
+        return mapper.writeValueAsString(node);
+    }
+
+    public static String parseIsoToJson(String isoRaw) throws Exception {
+        if (isoRaw == null || isoRaw.trim().isEmpty()) {
+            throw new IllegalArgumentException("Empty ISO message");
+        }
+
+        Map<String, String> fields = parseKeyValuePairs(isoRaw, "\\|");
+        ObjectNode node = mapper.createObjectNode();
+
+        node.put("txnId", fields.getOrDefault("txnId", "MISSING_TXN_ID"));
+        node.put("cardNumber", fields.getOrDefault("cardNumber", null));
+        node.put("currency", fields.getOrDefault("currency", null));
+        node.put("merchantId", fields.getOrDefault("merchantId", null));
+        node.put("terminalId", fields.getOrDefault("terminalId", null));
+        node.put("responseCode", fields.getOrDefault("responseCode", null));
+        node.put("channel", fields.getOrDefault("channel", null));
+        node.putNull("batchId");
+        node.putNull("schemeName");
+        node.put("authCode", fields.getOrDefault("authCode", null));
+        node.put("sourceType", "BANK_SWITCH");
+        node.put("rawSourceRecord", isoRaw);
+
+        String amountStr = fields.get("amount");
+        if (amountStr != null && !amountStr.isEmpty()) {
+            try {
+                node.put("amount", new BigDecimal(amountStr));
+            } catch (NumberFormatException e) {
+                node.put("amount", amountStr);
+            }
+        } else {
+            node.putNull("amount");
+        }
+
+        String timestamp = fields.get("txnTimestamp");
+        if (timestamp != null && !timestamp.isEmpty()) {
+            node.put("txnTimestamp", timestamp);
+        } else {
+            node.putNull("txnTimestamp");
+        }
+
+        return mapper.writeValueAsString(node);
+    }
+
+    public static String parseCsvToJson(String csvRaw) throws Exception {
+        if (csvRaw == null || csvRaw.trim().isEmpty()) {
+            return null;
+        }
+
+        String[] parts = csvRaw.split(",", -1);
+
+        ObjectNode node = mapper.createObjectNode();
+
+        String dateStr = parts.length > 0 ? parts[0] : "";
+        String schemeName = parts.length > 1 ? parts[1] : "";
+        String txnId = parts.length > 2 ? parts[2] : "MISSING_TXN_ID";
+        String cardNumber = parts.length > 3 ? parts[3] : "";
+        String amountStr = parts.length > 4 ? parts[4] : "";
+        String currency = parts.length > 5 ? parts[5] : "";
+        String merchantId = parts.length > 6 ? parts[6] : "";
+        String terminalId = parts.length > 7 ? parts[7] : "";
+        String responseCode = parts.length > 8 ? parts[8] : "";
+        String batchId = parts.length > 9 ? parts[9] : "";
+
+        node.put("txnId", txnId);
+        node.put("cardNumber", cardNumber.isEmpty() ? null : cardNumber);
+        node.put("currency", currency.isEmpty() ? null : currency);
+        node.put("merchantId", merchantId.isEmpty() ? null : merchantId);
+        node.put("terminalId", terminalId.isEmpty() ? null : terminalId);
+        node.put("responseCode", responseCode.isEmpty() ? null : responseCode);
+        node.put("batchId", batchId.isEmpty() ? null : batchId);
+        node.put("schemeName", schemeName.isEmpty() ? null : schemeName);
+        node.putNull("channel");
+        node.putNull("authCode");
+        node.put("sourceType", "SCHEME_FILE");
+        node.put("rawSourceRecord", csvRaw);
+
+        if (!amountStr.isEmpty()) {
+            try {
+                node.put("amount", new BigDecimal(amountStr));
+            } catch (NumberFormatException e) {
+                node.put("amount", amountStr);
+            }
+        } else {
+            node.putNull("amount");
+        }
+
+        // Date parsing logic handles both yyyy-MM-dd and dd/MM/yyyy
+        if (!dateStr.isEmpty()) {
+            boolean parsed = false;
+            // Try yyyy-MM-dd
+            try {
+                LocalDateTime txnTimestamp = LocalDateTime.parse(dateStr + "T00:00:00");
+                node.put("txnTimestamp", txnTimestamp.toString());
+                parsed = true;
+            } catch (Exception ignored) {
+            }
+            // Try dd/MM/yyyy
+            if (!parsed) {
+                try {
+                    LocalDateTime txnTimestamp = LocalDateTime.parse(dateStr + "T00:00:00", SLASH_DATE_FORMAT);
+                    node.put("txnTimestamp", txnTimestamp.toString());
+                    parsed = true;
+                } catch (Exception ignored2) {
+                }
+            }
+            // Fallback: raw string if unparseable
+            if (!parsed) {
+                node.put("txnTimestamp", dateStr);
+            }
+        } else {
+            node.putNull("txnTimestamp");
+        }
+
+        if (parts.length < 7) {
+            System.out.println("Processing short CSV record (" + parts.length + " fields): " + csvRaw);
+        }
+
+        return mapper.writeValueAsString(node);
+    }
+
+    private static Map<String, String> parseKeyValuePairs(String input, String delimiterRegex) {
+        Map<String, String> map = new HashMap<>();
+        if (input == null || input.trim().isEmpty()) {
+            return map;
+        }
+
+        String[] pairs = input.split(delimiterRegex);
+        for (String pair : pairs) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2) {
+                map.put(kv[0].trim(), kv[1].trim());
+            }
+        }
+        return map;
+    }
+
+    private static String extractField(String isoRaw, String key) {
+        Map<String, String> map = parseKeyValuePairs(isoRaw, "\\|");
+        return map.getOrDefault(key, "UNKNOWN");
+    }
+
+    private static String extractTxnIdFromCsv(String csvRaw) {
+        if (csvRaw == null || csvRaw.trim().isEmpty()) {
+            return "UNKNOWN";
+        }
+
+        String[] parts = csvRaw.split(",", -1);
+        if (parts.length > 2) {
+            return parts[2].isEmpty() ? "EMPTY_TXN_ID" : parts[2];
+        }
+        return "SHORT_CSV_RECORD";
+    }
+}

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ buildmm:
 # ── Running Services Locally ───────────────────────────────────────────
 
 runi:
-  mvn spring-boot:run -pl ingestion-service
+  mvn spring-boot:run -pl ingestion-service -DskipTests
 
 runm:
   mvn spring-boot:run -pl match-engine

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-    <project xmlns="http://maven.apache.org/POM/4.0.0"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -8,57 +8,46 @@
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Recon Engine</name>
-    <description>Demo: Multi-module Card Reconciliation Engine for Interview</description>
 
-    <!-- List all microservice modules (folders) here -->
-   <modules>
-    <module>ingestion-service</module>
-    <module>match-engine</module>
-    <module>report-service</module>
-    <module>exception-api</module>
-    <module>scheduler</module>
-    <module>monitor-metrics</module>
-</modules>
-
+    <modules>
+        <module>ingestion-service</module>
+        <module>match-engine</module>
+        <module>report-service</module>
+        <module>exception-api</module>
+        <module>scheduler</module>
+        <module>monitor-metrics</module>
+    </modules>
 
     <properties>
         <java.version>21</java.version>
         <spring.boot.version>3.2.6</spring.boot.version>
-        <!-- Add other shared versions as needed -->
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <version>${spring.boot.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring.boot.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring.boot.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- Add more shared dependencies as needed, e.g., kafka, cassandra, postgres, micrometer, etc. -->
-    </dependencies>
-</dependencyManagement>
+        <dependencies>
+            <!-- Import Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>
             <plugins>
-                <!-- Spring Boot Maven Plugin for all modules -->
+                <!-- Spring Boot Maven Plugin -->
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring.boot.version}</version>
                 </plugin>
-                <!-- Maven Compiler Plugin -->
+                <!-- Compiler -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -68,14 +57,21 @@
                         <target>${java.version}</target>
                     </configuration>
                 </plugin>
-                <!-- Surefire Plugin for running tests -->
+                <!-- Surefire -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <!-- Add more plugins as you need -->
             </plugins>
         </pluginManagement>
     </build>
+
+    <!-- Use Maven Central only -->
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </repositories>
 </project>

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,50 @@
+# Tools
+
+This directory contains utility tools for development and monitoring.
+
+## AKHQ - Kafka Web UI
+
+AKHQ is a lightweight web UI for managing and monitoring Kafka clusters.
+
+### Setup
+
+1. Ensure your Kafka broker is running locally on `localhost:9092`.
+
+2. Run AKHQ with:
+
+    ```bash
+    cd tools
+    java \
+    -Dmicronaut.config.files=./application.yml \
+    -Dmicronaut.server.port=8081 \
+    -jar akhq-0.25.1-all.jar
+    ```
+
+
+
+
+3. Access the web UI at: [http://localhost:8081](http://localhost:8081)
+
+### Features
+
+* Browse Kafka topics, partitions, and messages.
+* View consumer groups and lag.
+* Produce and consume messages interactively.
+* Monitor cluster health and configurations.
+
+### Notes
+
+* Change the `--server.port` if `8081` is occupied.
+* This tool is for development and monitoring only; do not use in production without proper security.
+
+---
+
+Place any other dev utilities or monitoring tools here for easy access.
+
+```
+
+Let me know if you want it more detailed or tailored!
+
+```
+
+```

--- a/tools/application.yml
+++ b/tools/application.yml
@@ -1,0 +1,11 @@
+micronaut:
+    server:
+        port: 8081
+
+akhq:
+    connections:
+        kafka-local:
+            properties:
+                bootstrap.servers: localhost:9092
+            security:
+                enabled: false


### PR DESCRIPTION
feat(ingestion-service): complete end-to-end ingestion pipeline with raw producers, normalization, validation, deduplication, and forwarding to ingested topic
- Added raw data producers simulating ISO (bank) and CSV (scheme) transactions to respective Kafka raw topics
- Implemented Kafka consumers for bank and scheme raw topics to ingest and process raw messages
- Normalized and validated transaction DTOs using JSR-380 annotations for strong schema enforcement
- Added deduplication logic with thread-safe in-memory cache to filter duplicate transactions
- Forwarded clean, valid, and unique records to downstream **ingested-txn-topic** for match engine consumption
- Included detailed logging for observability of processing counts, errors, and deduplication events
- Verified end-to-end Kafka message flow from raw producers through ingestion service to clean output topic
- Updated README with pipeline overview and clear instructions for integration with the downstream match engine
- Note: Metrics exposure and monitoring endpoints planned for future enhancement phases

---